### PR TITLE
fix(customer): remove dist folder from .gitignore to push js/css files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,10 +78,6 @@ typings/
 # Next.js build output
 .next
 
-# Nuxt.js build / generate output
-.nuxt
-dist
-
 # Gatsby files
 .cache/
 # Comment in the public line in if your project uses Gatsby and *not* Next.js


### PR DESCRIPTION
This project doesn't use Nuxt so it's risk free to remove Nuxt related folders from .gitignore.

Without this adjustment it's not possible to collaborate on this project in your own repo because all the css and js files of the customer frontend are missing in git.